### PR TITLE
Include `enqueued_at` in payload

### DIFF
--- a/lib/rubykiq/client.rb
+++ b/lib/rubykiq/client.rb
@@ -176,6 +176,9 @@ module Rubykiq
       # provide a job ID
       pre_normalized_item[:jid] = ::SecureRandom.hex(12)
 
+      # Sidekiq::Queue#latency (used in sidekiq web), requires `enqueued_at`
+      pre_normalized_item[:enqueued_at] = Time.now.to_f
+
       pre_normalized_item
     end
 

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -71,6 +71,7 @@ describe Rubykiq::Client do
                 raw_jobs.each do |job|
                   job = MultiJson.decode(job, symbolize_keys: true)
                   expect(job).to have_key(:jid)
+                  expect(job[:enqueued_at]).to be_within(1).of(Time.now.to_f)
                 end
               end
             end


### PR DESCRIPTION
Without this, sidekiq-web responds with a 500 if a rubykiq job is at the top of
the queue.

Since mperham/sidekiq/20c616e97196e2dae585ccce1a8526a73de003bb, `enqueued_at` is
required by [this line](https://github.com/mperham/sidekiq/blob/f75c91a5f4a295a4565ae55140f028d1d096fc40/lib/sidekiq/api.rb#L77).
